### PR TITLE
bug fix for heroku- please push to heroku

### DIFF
--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -116,6 +116,12 @@ router.post(
       due,
       public,
     });
+
+    const categories = await Category.findAll({
+      where: {
+        userId: res.locals.user.id
+      }
+    })
     // console.log(categoryId)
     if (validatorErrors.isEmpty()) {
       await task.save();


### PR DESCRIPTION
Currently on heroku, this bug exists:

1. Go to add task
2. Click add task without typing anything into the fields
3.  You're going to get an error saying categories is not defined, and you will not see the proper validators doing their job

This bug fix, fixes that and now our app is in supremely good shape